### PR TITLE
Update Readme with MacOS setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,44 @@
 #  Coordonnées
 
-#  Dependencies
+#  System Dependencies
 
-You will need the following dependencies in order to use SpatialLite : 
+You will need the following dependencies in order to use SpatialLite : SQLite, Spatialite, GDAL.
 
-Ubuntu / Debian
+## Ubuntu / Debian
+
+SQLite should be installed on the system by default.
+
 ```
 sudo apt-get install gdal-bin libgdal-dev libsqlite3-mod-spatialite
 ```
+
+## MacOS
+
+There should already be a system version of SQLite but in a version that does not support extensions
+which means you will need to install another version. This can be done via Brew.
+
+```
+brew update
+brew install sqlite3
+brew install libspatialite
+brew install spatialite-tools
+brew install gdal
+```
+
+After that you need to make sure that version of SQLite is used by adding it to your `PATH`. If you're using ZSH this can be done with:
+
+```
+echo "export PATH=\"$(brew --prefix)/opt/sqlite/bin:\$PATH\"" >> ~/.zshrc
+```
+
+Finally, SQLite needs to be able to find the Spatialite library installed by Brew. Peewee does not
+seem to use the `SPATIALITE_LIBRARY_PATH` environment variable unfortunately. For running commands
+locally using uv a workaround is to symlink it to the Python install managed by uv.
+
+  * Find the root folder used by uv with `uv python dir`.
+  * Find the version of Python used for this project
+  * Synlink Spatialite with
+    `ln -s $(brew --prefix)/lib/mod_spatialite.dylib $(uv python dir)/<PYTHON_VERSION>/lib/mod_spatialite.dylib`
 
 # Repo structure
 


### PR DESCRIPTION
Installing Spatialite is a bit more complicated on MacOS due to the system version of SQLite that doesn't support extensions. With Brew and just a bit of hacking it seems to be feasible though.