### PR TITLE
fix/coordo-package-main-entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This file is here only to support direct import for development",
   "license": "ISC",
   "author": "",
-  "main": "js/index.js",
+  "main": "coordo-ts/index.ts",
   "dependencies": {
     "maplibre-gl": "^5.16.0"
   }


### PR DESCRIPTION
Modif du package.json pour qu'il pointe bien vers coordo-ts/index.ts

Remarques : 

Pour télécharger la lib Coordo depuis cette branche, un npm install après avoir supprimé la la lib et changé le package.json comme dans le readme n'a pas suffit, j'ai du aussi supprimer le package-lock.json qui bloquait sur l'ancienne version à ce niveau la :
<img width="769" height="133" alt="image" src="https://github.com/user-attachments/assets/5b248351-58bc-4196-bf11-eb9ed970eb93" />
