### PR TITLE
fix: dispatch map:ready after styledata to ensure layers metadata are…

### DIFF
--- a/coordo-ts/index.ts
+++ b/coordo-ts/index.ts
@@ -160,6 +160,8 @@ export function createMap(
         );
       }
     });
+
+    init();
   });
 
   function init() {
@@ -250,7 +252,6 @@ export function createMap(
     popupRemovers[layerId] = removeListeners;
   }
 
-  init();
   return {
     mapInstance: map,
     hideLayer,


### PR DESCRIPTION
fix: dispatcher map:ready après styledata pour garantir l'accès aux metadata des layers depuis le frontend React.

**Problème**
La fonction init() était appelée de manière synchrone à la fin de createMap(), ce qui dispatchait l'événement map:ready immédiatement. Or, le callback map.on("styledata", ...) — qui ajoute les controls, configure les popups et charge les metadata des layers — s'exécute de manière asynchrone, après le chargement du style.

Résultat : quand le front React écoutait map:ready pour interagir avec la carte, les layers et leurs metadata n'étaient pas encore disponibles. Un appel à getLayerMetadata() dans ce listener retournait undefined.

**Correction**
L'appel à init() est déplacé à la fin du callback styledata, après l'ajout des controls et la configuration des popups. Ainsi, map:ready n'est dispatché que lorsque la carte est réellement prête à être utilisée.

