### PR TITLE
fix: use setHTML instead of setText for popup content rendering

### DIFF
--- a/coordo-ts/index.ts
+++ b/coordo-ts/index.ts
@@ -223,7 +223,7 @@ export function createMap(
         const popup = new maplibregl.Popup().setLngLat(coordinates);
         const content = callback(properties);
         if (typeof content == "string") {
-          popup.setText(content);
+          popup.setHTML(content);
         } else {
           popup.setDOMContent(content);
         }


### PR DESCRIPTION
Fixes #31 

Fix popup content being rendered as plain text instead of HTML.

## Problem

When a layer defines a `popup.html` template in the config, the rendered content
was passed to `popup.setText()` which escapes HTML tags, causing them to appear
as raw text in the popup instead of being rendered.

## Solution

Replace `popup.setText(content)` with `popup.setHTML(content)` when the content
comes from an HTML template.