### PR TITLE
Fix Makefile build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 build:
 	cd coordo-ts && npm install && npm run build
-	mkdir coordo-py/coordo/static/
+	mkdir -p coordo-py/coordo/static/
 	cp -r coordo-ts/dist/* coordo-py/coordo/static/


### PR DESCRIPTION
## Problem

Lorsqu'on run `make build`:

 - la 1ère fois ça crash si on n'a jamais run `npm install` dans `coordo-ts`
 - ensuite ça crash car le dossier `coordo-py/coordo/static/` existe déjà

## Solution

1.  run `npm install` avant `npm run build`
2. ne créer le dossier que si nécessaire