### PR TITLE
fix: geometry column detection fails with DuckDB spatial extension

### DIFF
--- a/coordo-py/coordo/datapackage/__init__.py
+++ b/coordo-py/coordo/datapackage/__init__.py
@@ -411,7 +411,7 @@ class DataPackage(BaseModel):
         query_str = str(query.compile(compile_kwargs={"literal_binds": True}))
         relation = conn.sql(query_str)
         table = relation.arrow().read_all()
-        if any(str(col[1]) == "GEOMETRY" for col in relation.description):
+        if any(str(col[1]).startswith("GEOMETRY") for col in relation.description):
             out = gpd.GeoDataFrame.from_arrow(table)
         else:
             out = pd.DataFrame.from_arrow(table)


### PR DESCRIPTION
## Problem

When a geometry column is computed via `centroid()` or any other spatial function,
`read_resource()` always returns a plain `DataFrame` instead of a `GeoDataFrame`,
causing a crash:

AssertionError: No geometries in the layer output.

## Cause

The geometry detection was checking `col[1].id == "geometry"`, but DuckDB returns
`"blob"` via `.id` for geometry columns (stored internally as WKB binary).

Using `str(col[1])` gives the human-readable type name — but DuckDB may return
`"GEOMETRY('EPSG:4326')"` instead of `"GEOMETRY"` alone depending on the context.
A strict equality check is therefore always false.

## Fix

# Before
if any(col[1].id == "geometry" for col in relation.description):

# After
if any(str(col[1]).startswith("GEOMETRY") for col in relation.description):

`startswith("GEOMETRY")` covers all variants of the DuckDB spatial type.
