### PR TITLE
feat(layer-controls): Make it possible to sync layers controls with consumer via events

### DIFF
--- a/coordo-ts/src/events.ts
+++ b/coordo-ts/src/events.ts
@@ -1,5 +1,5 @@
 export const EVENTS = {
   LAYER_HIDE: (layerId: string) => `layer:${layerId}:hide`,
   LAYER_SHOW: (layerId: string) => `layer:${layerId}:show`,
-  MAP_READY: "map:ready"
+  MAP_READY: "map:ready",
 } as const;

--- a/coordo-ts/src/index.ts
+++ b/coordo-ts/src/index.ts
@@ -4,7 +4,6 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import "./index.css";
 
 import { EVENTS } from "./events";
-import { LAYER_VISIBILITY } from "./layers/controls";
 import { makeSetLayerFilters } from "./layers/filters";
 import { makeSetLayerPopup } from "./layers/popup";
 import { addStyleDataListener } from "./map/style-data";
@@ -41,14 +40,6 @@ export function createMap(
     zoom: mergedOptions.zoom,
   });
 
-  function hideLayer(layerId: string) {
-    map.setLayoutProperty(layerId, "visibility", LAYER_VISIBILITY.NONE);
-  }
-
-  function showLayer(layerId: string) {
-    map.setLayoutProperty(layerId, "visibility", LAYER_VISIBILITY.VISIBLE);
-  }
-
   function getLayerMetadata(layerId: string) {
     return map.getLayer(layerId)?.metadata;
   }
@@ -80,7 +71,7 @@ export function createMap(
     el.dispatchEvent(event);
   }
 
-  addStyleDataListener({
+  const { hideLayer, showLayer } = addStyleDataListener({
     dispatchEventToConsumer,
     map,
     onSuccess: init,

--- a/coordo-ts/src/layers/controls.ts
+++ b/coordo-ts/src/layers/controls.ts
@@ -21,12 +21,14 @@ export class LayerControl {
   private _container?: HTMLElement;
   private _panel?: HTMLElement;
   private _dispatchEvent: (eventName: string) => void;
+  private _syncFunctions: Record<string, () => void>;
 
   constructor({
     dispatchEventToConsumer,
   }: { dispatchEventToConsumer: (event: CustomEvent) => void }) {
     this._dispatchEvent = (eventName: string) =>
       dispatchEventToConsumer(new CustomEvent(eventName));
+    this._syncFunctions = {};
   }
 
   onAdd(map: MapLibreMap) {
@@ -80,8 +82,16 @@ export class LayerControl {
           "visibility",
           isChecked ? LAYER_VISIBILITY.VISIBLE : LAYER_VISIBILITY.NONE,
         );
-        this._dispatchEvent(isChecked ? EVENTS.LAYER_SHOW(layerId) : EVENTS.LAYER_HIDE(layerId));
+        this._dispatchEvent(
+          isChecked ? EVENTS.LAYER_SHOW(layerId) : EVENTS.LAYER_HIDE(layerId),
+        );
       });
+
+      const syncCheckboxState = () => {
+        checkbox.checked = this._isChecked(layerId);
+      };
+
+      this._syncFunctions[layerId] = syncCheckboxState;
 
       label.appendChild(checkbox);
       label.appendChild(document.createTextNode(` ${layerId}`));
@@ -93,5 +103,14 @@ export class LayerControl {
   onRemove() {
     this._container?.remove();
     this._map = undefined;
+  }
+
+  syncState() {
+    const layers = this._map?.getStyle().layers;
+
+    layers?.forEach((layer: LayerSpecification) => {
+      const layerId = layer.id;
+      this._syncFunctions[layerId]?.();
+    });
   }
 }

--- a/coordo-ts/src/map/style-data.ts
+++ b/coordo-ts/src/map/style-data.ts
@@ -7,7 +7,7 @@ import type {
 } from "maplibre-gl";
 import { LngLatBounds, NavigationControl, ScaleControl } from "maplibre-gl";
 
-import { CONTROLS, LayerControl } from "../layers/controls";
+import { CONTROLS, LAYER_VISIBILITY, LayerControl } from "../layers/controls";
 import type { SetLayerPopupParams } from "../layers/popup";
 import type { LayerMetadata } from "../types";
 
@@ -36,9 +36,10 @@ export function addStyleDataListener({
   let style: StyleSpecification | undefined;
   let controlsAdded = false;
 
+  const layerControl = new LayerControl({ dispatchEventToConsumer });
+
   map.on("styledata", () => {
     if (controlsAdded) {
-      console.warn("[STYLEDATA] Controls already setup.");
       return;
     }
     controlsAdded = true;
@@ -66,7 +67,7 @@ export function addStyleDataListener({
           break;
 
         case CONTROLS.LAYER:
-          map.addControl(new LayerControl({ dispatchEventToConsumer }), config.position);
+          map.addControl(layerControl, config.position);
           break;
 
         case CONTROLS.SCALE:
@@ -111,8 +112,24 @@ export function addStyleDataListener({
     onSuccess?.();
   });
 
+  function hideLayer(layerId: string) {
+    // Update the layout property
+    map.setLayoutProperty(layerId, "visibility", LAYER_VISIBILITY.NONE);
+    // Trigger an internal synchronization of the Controls Layer
+    layerControl.syncState();
+  }
+
+  function showLayer(layerId: string) {
+    // Update the layout property
+    map.setLayoutProperty(layerId, "visibility", LAYER_VISIBILITY.VISIBLE);
+    // Trigger an internal synchronization of the Controls Layer
+    layerControl.syncState();
+  }
+
   return {
     controlsAdded,
+    hideLayer,
+    showLayer,
     style,
   };
 }


### PR DESCRIPTION
## Goal

In D4T website, we have 2 ways to set layers (example: satellite):
- in the map-sidebar categories filters
- in the internal coordo ts controls layer

2 ways must remain in sync. How ? Via a single source of truth (being the state of the map)

-> When the consumer uses hideLayer or showLayer => these functions must trigger a sync in the LayerControl 
-> Whn the internal controls layer hides or shows a layer => an event must be sent to the consumer to enforce synchronization

This is why I'm doing here:
- Add EVENTS to standardize communication via CustomEvents
- Add sync functions in LayerControl so that evensts from the top can trigger a new sync of the checkbox
- Dispatch events to the dependant when using LayerControl