### PR TITLE
Feat: Enable complex boolean expression in Lark Grammar

### DIFF
--- a/configs/all4trees_config.json
+++ b/configs/all4trees_config.json
@@ -31,7 +31,9 @@
       "resource": "inventaire_id",
       "columns": {
         "geom": "gps.merge().centroid()",
-        "test": "ind.list(0 if dhp3 > 0 and dhp4 > 0 else 2)",
+        "for": "for",
+        "cod": "cod",
+        "double_condition": "ind.list(0 if dhp3 > 0 and dhp4 > 0 else 2)",
         "aerial_biomass_volume": "ind.sum(0.0673 * (dens_bois.value * (dhp1 + dhp2 + dhp3 + dhp4 + dhp5 + dhp6 + dhp7 + dhp8 + dhp9 + dhp10)^2 * haut)^0.976 if etat = 1) / (20^2 * pi() / 10000)",
         "TREE_species_counts": "ind.histogram(ess_arb)",
         "EPF_tree_density": "ind.count(1 if etat = 2) / (20^2 * pi() / 10000)",

--- a/configs/data4trees_config.json
+++ b/configs/data4trees_config.json
@@ -31,6 +31,7 @@
       "resource": "inventaire_id",
       "columns": {
         "geom": "gps.merge().centroid()",
+        "test": "ind.list(0 if dhp3 > 0 and dhp4 > 0 else 2)",
         "aerial_biomass_volume": "ind.sum(0.0673 * (dens_bois.value * (dhp1 + dhp2 + dhp3 + dhp4 + dhp5 + dhp6 + dhp7 + dhp8 + dhp9 + dhp10)^2 * haut)^0.976 if etat = 1) / (20^2 * pi() / 10000)",
         "TREE_species_counts": "ind.histogram(ess_arb)",
         "EPF_tree_density": "ind.count(1 if etat = 2) / (20^2 * pi() / 10000)",

--- a/coordo-py/coordo/sql/evaluator.py
+++ b/coordo-py/coordo/sql/evaluator.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from pygeofilter.ast import AstType
-from sqlalchemy import Integer, and_, case, cast, func, select, text
+from sqlalchemy import Integer, and_, case, cast, func, or_, select, text
 
 from coordo.sql.helpers import AGGREGATES, SPATIAL_FUNCTIONS
 from coordo.sql.mapper import FieldMapper
@@ -127,6 +127,10 @@ class SQLEvaluator:
                 expr = lhs.expr <= rhs.expr
             case "in":
                 expr = rhs.expr.contains(lhs.expr)
+            case "or" | "||":
+                expr = or_(lhs.expr, rhs.expr)
+            case "and" | "&&":
+                expr = and_(lhs.expr, rhs.expr)
             case _:
                 raise ValueError("Unsupported comparison :", node.op)
 

--- a/coordo-py/coordo/sql/evaluator.py
+++ b/coordo-py/coordo/sql/evaluator.py
@@ -177,7 +177,7 @@ class SQLEvaluator:
         if node.name.lower() in AGGREGATES:
             query = self.base_query
             for join, on in joins:
-                query = query.join(join, on)
+                query = query.join(join, on, isouter=True)
             cte = query.add_columns(f.label("value")).cte()
             return Context(
                 cte.columns["value"],

--- a/coordo-py/coordo/sql/parser.py
+++ b/coordo-py/coordo/sql/parser.py
@@ -9,14 +9,14 @@ from pygeofilter.ast import AstType, Node
 GRAMMAR = r"""
     ?start: expr
 
-    ?expr: sum ("if" boolean_expr ("else" expr)?)?
+    ?expr: sum ("if" condition ("else" expr)?)?
 
-    ?boolean_expr: boolean_or
+    ?condition: boolean_or -> bool_op
 
-    ?boolean_or: boolean_and BOOL_OR_OP boolean_or
+    ?boolean_or: boolean_and OR boolean_or -> bool_op
             | boolean_and
 
-    ?boolean_and: comparison BOOL_AND_OP boolean_and
+    ?boolean_and: comparison AND boolean_and -> bool_op
             | comparison
 
     SUM: "+" | "-"
@@ -56,8 +56,8 @@ GRAMMAR = r"""
 
     comparison: sum OP sum
 
-    BOOL_AND_OP: "and" | "&&"
-    BOOL_OR_OP: "or" | "||"
+    AND: "and" | "&&"
+    OR: "or" | "||"
     OP: ">" | "<" | "=" | "!=" | ">=" | "<=" | "in"
     QUOTED: /'[^']*'|"[^"]*"/
 
@@ -147,20 +147,12 @@ class SQLTransformer(Transformer):
     def expr(self, children):
         return Conditional(*children)
 
+    def bool_op(self, children):
+        if len(children) == 1:
+            return children[0]
+        return Comparison(*children)
+
     def comparison(self, children):
-        return Comparison(*children)
-
-    def boolean_expr(self, children):
-        return self.boolean_or(self, children)
-
-    def boolean_and(self, children):
-        if len(children) == 1:
-            return children[0]
-        return Comparison(*children)
-
-    def boolean_or(self, children):
-        if len(children) == 1:
-            return children[0]
         return Comparison(*children)
 
     def query(self, children):

--- a/coordo-py/coordo/sql/parser.py
+++ b/coordo-py/coordo/sql/parser.py
@@ -9,7 +9,15 @@ from pygeofilter.ast import AstType, Node
 GRAMMAR = r"""
     ?start: expr
 
-    ?expr: sum ("if" comparison ("else" expr)? )?
+    ?expr: sum ("if" boolean_expr ("else" expr)?)?
+
+    ?boolean_expr: boolean_or
+
+    ?boolean_or: boolean_and ( "||" | "or" ) boolean_or
+            | boolean_and
+
+    ?boolean_and: comparison ( "&&" | "and" ) boolean_and
+            | comparison
 
     SUM: "+" | "-"
 
@@ -26,8 +34,8 @@ GRAMMAR = r"""
     ?power: factor POW NUMBER -> op
         | factor
 
-    ?factor: "-" factor    -> op
-        | atom
+    ?factor: "-" factor -> op
+            | atom
 
     ?atom: call_chain
         | func_call
@@ -139,6 +147,19 @@ class SQLTransformer(Transformer):
 
     def comparison(self, children):
         return Comparison(*children)
+
+    def boolean_expr(self, children):
+        return self.boolean_or(self, children)
+
+    def boolean_and(self, children):
+        if len(children) == 1:
+            return children[0]
+        return BinaryOp(children[0], 'and', children[2])  # children[1] is the "&&" or "and" token
+
+    def boolean_or(self, children):
+        if len(children) == 1:
+            return children[0]
+        return BinaryOp(children[0], 'or', children[2])  # children[1] is the "||" or "or" token
 
     def query(self, children):
         return Query(*children)

--- a/coordo-py/coordo/sql/parser.py
+++ b/coordo-py/coordo/sql/parser.py
@@ -13,10 +13,10 @@ GRAMMAR = r"""
 
     ?boolean_expr: boolean_or
 
-    ?boolean_or: boolean_and ( "||" | "or" ) boolean_or
+    ?boolean_or: boolean_and BOOL_OR_OP boolean_or
             | boolean_and
 
-    ?boolean_and: comparison ( "&&" | "and" ) boolean_and
+    ?boolean_and: comparison BOOL_AND_OP boolean_and
             | comparison
 
     SUM: "+" | "-"
@@ -56,6 +56,8 @@ GRAMMAR = r"""
 
     comparison: sum OP sum
 
+    BOOL_AND_OP: "and" | "&&"
+    BOOL_OR_OP: "or" | "||"
     OP: ">" | "<" | "=" | "!=" | ">=" | "<=" | "in"
     QUOTED: /'[^']*'|"[^"]*"/
 
@@ -154,12 +156,12 @@ class SQLTransformer(Transformer):
     def boolean_and(self, children):
         if len(children) == 1:
             return children[0]
-        return BinaryOp(children[0], 'and', children[2])  # children[1] is the "&&" or "and" token
+        return Comparison(*children)
 
     def boolean_or(self, children):
         if len(children) == 1:
             return children[0]
-        return BinaryOp(children[0], 'or', children[2])  # children[1] is the "||" or "or" token
+        return Comparison(*children)
 
     def query(self, children):
         return Query(*children)


### PR DESCRIPTION
This PR adds 2 thinks: 
- the use of complex boolean expressions for evaluating conditions
- perform outer_joins instead of left join in order to preseve rows that were not mapped during the join