### PR TITLE
Feat:  Support 'layerType' key config.json

### DIFF
--- a/configs/seed_config.json
+++ b/configs/seed_config.json
@@ -25,13 +25,34 @@
       "style": { "paint": { "line-color": "hsl(248,7%,66%)" } }
     },
     {
-      "id": "inventaire",
+      "id": "seed",
       "type": "datapackage",
+      "layerType": "circle",
       "path": "../catalog/seed/datapackage.json",
       "resource": "survey",
+      "columns": {
+        "geom": "geom",
+        "id": "OGC_FID",
+        "orga": "votre_orga",
+        "responsable": "nom_du_res",
+        "date_plantation": "date_de_pl",
+        "type_plant": "type_de_pl",
+        "prelevement_mangrove": "trace_de_p",
+        "test": "round(random() * 4 ) + 1"
+      },
       "popup": {
         "trigger": "click"
       }
+    },
+    {
+      "id": "seed_point",
+      "type": "datapackage",
+      "path": "../catalog/seed/datapackage.json",
+      "resource": "survey",
+      "columns": {
+        "geom": "centroid(geom)"
+      },
+      "maxzoom": 13
     }
   ],
   "controls": [

--- a/coordo-py/coordo/map/datapackage.py
+++ b/coordo-py/coordo/map/datapackage.py
@@ -33,6 +33,7 @@ class DataPackageLayer(BaseLayerModel):
     filter: str | None = None
     groupby: list[str] | None = None
     columns: dict[str, str] | None = None
+    layerType: str | None = None
     popup: Popup | None = None
 
     def to_maplibre(self, base_path):
@@ -40,18 +41,7 @@ class DataPackageLayer(BaseLayerModel):
         resource = package.get_resource(name=self.resource)
         data = self.get_data(base_path=base_path)
 
-        # We check the type of the first non-null geometry, it doesn't support yet mixed geometries
-        geom_type = (
-            next(f["geometry"] for f in data["features"] if f["geometry"])["type"]
-            if data["features"]
-            else "Point"
-        )
-        if "Polygon" in geom_type:
-            layer_type = "fill"
-        elif "LineString" in geom_type:
-            layer_type = "line"
-        else:
-            layer_type = "circle"
+        layer_type = self.layerType or self.infer_layer_type(data["features"])
 
         source = GeoJSONSource(type="geojson", data=data)
         metadata = {
@@ -97,3 +87,20 @@ class DataPackageLayer(BaseLayerModel):
         )
         assert isinstance(df, GeoDataFrame), "No geometry column found."
         return df.to_geo_dict(show_bbox=True)  # type: ignore
+    
+    def infer_layer_type(self, features):
+        # We check the type of the first non-null geometry, it doesn't support yet mixed geometries
+        geom_type = (
+            next(f["geometry"] for f in features if f["geometry"])["type"]
+            if features
+                else "Point"
+        )
+        if "Polygon" in geom_type:
+            layer_type = "fill"
+        elif "LineString" in geom_type:
+            layer_type = "line"
+        else:
+            layer_type = "circle"
+
+        return layer_type
+


### PR DESCRIPTION
### Context

This PR is related to #64 and #74.
We want to create layers of type "symbol" in order to show icons instead of circles as data points in the map.
However, currently the layer type is inferred from the geometry type. But in the case of 'symbols' the layer type can be anything and therfore it should be set directly in the config.json. 

Another strategy would be to infer the layer type into 'symbol' in case other data keys are present in the config.json, like "layout": { "icon-image": "someUrl" } for instance, but it would make the code a bit more complex.