### PR TITLE
Fix(popup): condition check for popup display

### DIFF
--- a/coordo-ts/src/layers/popup.ts
+++ b/coordo-ts/src/layers/popup.ts
@@ -126,10 +126,12 @@ export function makeSetLayerPopup({ map }: { map: MapLibreMap }) {
         popup.addTo(map);
       } else if (!lngLat) {
         console.warn("Missing property lngLat on event : ", ev);
+      } else if (!ev.features) {
+        console.warn("Event features not found");
       } else if (!(Number(id) >= 0)) {
         console.warn("event feature id is invalid: ", id);
       } else if (!eventProps) {
-        console.warn("Event Props not found", eventProps);
+        console.warn("Event feature properties not found", eventProps);
       }
     };
 

--- a/coordo-ts/src/layers/popup.ts
+++ b/coordo-ts/src/layers/popup.ts
@@ -97,10 +97,10 @@ export function makeSetLayerPopup({ map }: { map: MapLibreMap }) {
     }
 
     const onTrigger = async (ev: MapLayerMouseEvent | MapLayerTouchEvent) => {
-      const geometry = ev.features?.[0]?.geometry;
+      const lngLat = ev.lngLat;
       const eventProps = ev.features?.[0]?.properties;
       const id = ev.features?.[0]?.id;
-      if (geometry && id && eventProps) {
+      if (lngLat && Number(id) >= 0 && eventProps) {
         /** @todo Remove "any" casting  */
         const popup = new Popup(popupConfig).setLngLat(ev.lngLat);
 
@@ -124,6 +124,12 @@ export function makeSetLayerPopup({ map }: { map: MapLibreMap }) {
         }
 
         popup.addTo(map);
+      } else if (!lngLat) {
+        console.warn("Missing property lngLat on event : ", ev);
+      } else if (!(Number(id) >= 0)) {
+        console.warn("event feature id is invalid: ", id);
+      } else if (!eventProps) {
+        console.warn("Event Props not found", eventProps);
       }
     };
 


### PR DESCRIPTION
### Context

We had a condition like this : 

`if (geometry && id && eventProps)`

However `id` wat typed as string or number and the check was failing when `id` was equal to `0`.

Moreover, `geometry` was checked but never accessed, because `ev.lngLat` was effectively used to set Popup position on the map. This has been fixed too.

I added some console warn in case the check was failing.
