### PR TITLE
Chore: Enrich Layer Metadata with references' schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,21 @@ build:
 
 catalog:
 	# All 4 Trees - Inventaire forestier
-	uv run coordo load kobotoolbox data/all4trees/inventaire/20250213_Inventaire_ID_QuestionnaireK.xlsx data/all4trees/inventaire/20251017_Inventaire_ID_Donnees.xlsx --package catalog/inventaire
-	uv run coordo load file data/all4trees/inventaire/dens_bois.csv --package catalog/inventaire
+	uv run coordo load kobotoolbox --add data/all4trees/inventaire/20250213_Inventaire_ID_QuestionnaireK.xlsx data/all4trees/inventaire/20251017_Inventaire_ID_Donnees.xlsx --package catalog/inventaire
+	uv run coordo load file --add data/all4trees/inventaire/dens_bois.csv --package catalog/inventaire
 	uv run coordo add-foreignkey ind.ess_arb dens_bois.ess_arb --package catalog/inventaire
-	uv run coordo load file data/all4trees/inventaire/inventaire_external.csv --package catalog/inventaire
+	uv run coordo load file --add data/all4trees/inventaire/inventaire_external.csv --package catalog/inventaire
 	uv run coordo add-foreignkey inventaire_id._id inventaire_external.index --package catalog/inventaire
-	uv run coordo load file data/all4trees/inventaire/dens_bois_mort.csv --package catalog/inventaire
+	uv run coordo load file --add data/all4trees/inventaire/dens_bois_mort.csv --package catalog/inventaire
 	uv run coordo add-foreignkey ind.decomp dens_bois_mort.decomp --package catalog/inventaire
-	uv run coordo load file data/all4trees/inventaire/constants.csv --package catalog/inventaire
-	uv run coordo load file data/all4trees/inventaire/meteo.csv --package catalog/inventaire
+	uv run coordo load file --add data/all4trees/inventaire/constants.csv --package catalog/inventaire
+	uv run coordo load file --add data/all4trees/inventaire/meteo.csv --package catalog/inventaire
 	uv run coordo add-foreignkey inventaire_id.for meteo.strat --package catalog/inventaire
 
 	# All 4 Trees - Enquête ménage
-	uv run coordo load kobotoolbox data/all4trees/enquete/20240808_EnqueteMenage_CDF_QuestionnaireK.xlsx data/all4trees/enquete/20241007_EnqueteMenage_CDF_Donnees.csv --package catalog/enquete
-	uv run coordo load file data/all4trees/enquete/socio_eco_gps.csv --package catalog/enquete
+	uv run coordo load kobotoolbox --add data/all4trees/enquete/20240808_EnqueteMenage_CDF_QuestionnaireK.xlsx data/all4trees/enquete/20241007_EnqueteMenage_CDF_Donnees.csv --package catalog/enquete
+	uv run coordo load file --add data/all4trees/enquete/socio_eco_gps.csv --package catalog/enquete
 	uv run coordo add-foreignkey enquete_menage_cdf.admi2 socio_eco_gps.admi2 --package catalog/enquete
 
 	# Seed - Survey
-	uv run coordo load file data/seed/survey.zip --package catalog/seed
+	uv run coordo load file --add data/seed/survey.zip --package catalog/seed

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,24 @@ build:
 	cd coordo-ts && npm install && npm run build
 	mkdir -p coordo-py/coordo/static/
 	cp -r coordo-ts/dist/* coordo-py/coordo/static/
+
+catalog:
+	# All 4 Trees - Inventaire forestier
+	uv run coordo load kobotoolbox data/all4trees/inventaire/20250213_Inventaire_ID_QuestionnaireK.xlsx data/all4trees/inventaire/20251017_Inventaire_ID_Donnees.xlsx --package catalog/inventaire
+	uv run coordo load file data/all4trees/inventaire/dens_bois.csv --package catalog/inventaire
+	uv run coordo add-foreignkey ind.ess_arb dens_bois.ess_arb --package catalog/inventaire
+	uv run coordo load file data/all4trees/inventaire/inventaire_external.csv --package catalog/inventaire
+	uv run coordo add-foreignkey inventaire_id._id inventaire_external.index --package catalog/inventaire
+	uv run coordo load file data/all4trees/inventaire/dens_bois_mort.csv --package catalog/inventaire
+	uv run coordo add-foreignkey ind.decomp dens_bois_mort.decomp --package catalog/inventaire
+	uv run coordo load file data/all4trees/inventaire/constants.csv --package catalog/inventaire
+	uv run coordo load file data/all4trees/inventaire/meteo.csv --package catalog/inventaire
+	uv run coordo add-foreignkey inventaire_id.for meteo.strat --package catalog/inventaire
+
+	# All 4 Trees - Enquête ménage
+	uv run coordo load kobotoolbox data/all4trees/enquete/20240808_EnqueteMenage_CDF_QuestionnaireK.xlsx data/all4trees/enquete/20241007_EnqueteMenage_CDF_Donnees.csv --package catalog/enquete
+	uv run coordo load file data/all4trees/enquete/socio_eco_gps.csv --package catalog/enquete
+	uv run coordo add-foreignkey enquete_menage_cdf.admi2 socio_eco_gps.admi2 --package catalog/enquete
+
+	# Seed - Survey
+	uv run coordo load file data/seed/survey.zip --package catalog/seed

--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,21 @@ build:
 
 catalog:
 	# All 4 Trees - Inventaire forestier
-	uv run coordo load kobotoolbox --add data/all4trees/inventaire/20250213_Inventaire_ID_QuestionnaireK.xlsx data/all4trees/inventaire/20251017_Inventaire_ID_Donnees.xlsx --package catalog/inventaire
-	uv run coordo load file --add data/all4trees/inventaire/dens_bois.csv --package catalog/inventaire
+	uv run coordo load kobotoolbox --action add data/all4trees/inventaire/20250213_Inventaire_ID_QuestionnaireK.xlsx data/all4trees/inventaire/20251017_Inventaire_ID_Donnees.xlsx --package catalog/inventaire
+	uv run coordo load file --action add data/all4trees/inventaire/dens_bois.csv --package catalog/inventaire
 	uv run coordo add-foreignkey ind.ess_arb dens_bois.ess_arb --package catalog/inventaire
-	uv run coordo load file --add data/all4trees/inventaire/inventaire_external.csv --package catalog/inventaire
+	uv run coordo load file --action add data/all4trees/inventaire/inventaire_external.csv --package catalog/inventaire
 	uv run coordo add-foreignkey inventaire_id._id inventaire_external.index --package catalog/inventaire
-	uv run coordo load file --add data/all4trees/inventaire/dens_bois_mort.csv --package catalog/inventaire
+	uv run coordo load file --action add data/all4trees/inventaire/dens_bois_mort.csv --package catalog/inventaire
 	uv run coordo add-foreignkey ind.decomp dens_bois_mort.decomp --package catalog/inventaire
-	uv run coordo load file --add data/all4trees/inventaire/constants.csv --package catalog/inventaire
-	uv run coordo load file --add data/all4trees/inventaire/meteo.csv --package catalog/inventaire
+	uv run coordo load file --action add data/all4trees/inventaire/constants.csv --package catalog/inventaire
+	uv run coordo load file --action add data/all4trees/inventaire/meteo.csv --package catalog/inventaire
 	uv run coordo add-foreignkey inventaire_id.for meteo.strat --package catalog/inventaire
 
 	# All 4 Trees - Enquête ménage
-	uv run coordo load kobotoolbox --add data/all4trees/enquete/20240808_EnqueteMenage_CDF_QuestionnaireK.xlsx data/all4trees/enquete/20241007_EnqueteMenage_CDF_Donnees.csv --package catalog/enquete
-	uv run coordo load file --add data/all4trees/enquete/socio_eco_gps.csv --package catalog/enquete
+	uv run coordo load kobotoolbox --action add data/all4trees/enquete/20240808_EnqueteMenage_CDF_QuestionnaireK.xlsx data/all4trees/enquete/20241007_EnqueteMenage_CDF_Donnees.csv --package catalog/enquete
+	uv run coordo load file --action add data/all4trees/enquete/socio_eco_gps.csv --package catalog/enquete
 	uv run coordo add-foreignkey enquete_menage_cdf.admi2 socio_eco_gps.admi2 --package catalog/enquete
 
 	# Seed - Survey
-	uv run coordo load file --add data/seed/survey.zip --package catalog/seed
+	uv run coordo load file --action add data/seed/survey.zip --package catalog/seed

--- a/README.md
+++ b/README.md
@@ -103,11 +103,9 @@ make build
 
 Import data into catalog
 
-```
-uv run coordo load kobotoolbox data/20250213_Inventaire_ID_QuestionnaireK.xlsx data/20251017_Inventaire_ID_Donnees.xlsx --package catalog/inventaire
-uv run coordo load file data/dens_bois.csv --package catalog/inventaire
-uv run coordo add-foreignkey ind.ess_arb dens_bois.ess_arb --package catalog/inventaire
-uv run coordo load kobotoolbox data/20240808_EnqueteMenage_CDF_QuestionnaireK.xlsx data/20241007_EnqueteMenage_CDF_Donnees.csv --package catalog/enquete
+```bash
+AWS_ACCESS_KEY_ID=<access_key_id> AWS_SECRET_ACCESS_KEY=<secret_access_key> aws s3 sync s3://coordonnees-upload ./data --delete --endpoint-url https://s3.fr-par.scw.cloud --region fr-par
+make catalog
 ```
 
 Serve a config file

--- a/coordo-py/coordo/map/datapackage.py
+++ b/coordo-py/coordo/map/datapackage.py
@@ -45,9 +45,12 @@ class DataPackageLayer(BaseLayerModel):
 
         source = GeoJSONSource(type="geojson", data=data)
         metadata = {
-            "schema": safe(resource, "schema").model_dump(
-                exclude_none=True, warnings="none"
-            ),
+            "resource": {
+                "schema": safe(resource, "schema").model_dump(
+                    exclude_none=True, warnings="none"
+                ),
+            },
+            "references": self.findAllResourceReferences(resource, package)
         }
         if self.popup:
             metadata.update(popup=self.popup.model_dump())
@@ -103,4 +106,19 @@ class DataPackageLayer(BaseLayerModel):
             layer_type = "circle"
 
         return layer_type
+    
+    def findAllResourceReferences(self, resource, package):
+        references = []
+        added_references = []
+        for res in package.resources:
+            for fk in res.schema.foreignKeys:
+                if fk.reference.resource == resource.name and res.name not in added_references:
+                    references.append({
+                        "name": res.name,
+                        "schema": safe(res, "schema").model_dump(
+                            exclude_none=True, warnings="none"
+                        )
+                    })
+                    added_references.append(res.name)
+        return references
 

--- a/coordo-ts/src/layers/filters.ts
+++ b/coordo-ts/src/layers/filters.ts
@@ -5,8 +5,6 @@
 
 import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
 
-import type { LayerMetadata } from "../types";
-
 export type SetLayerFiltersParams<T> = {
   layerId: string;
   filters: T;
@@ -47,11 +45,6 @@ export function makeSetLayerFilters({
       throw new Error(`[FILTERS] Layer ${layerId} doesn't exist.`);
     }
 
-    // Retrieve dataUrl froom layer configuration
-    const schema = (layer.metadata as LayerMetadata).schema;
-    if (!schema) {
-      throw new Error(`[FILTERS] Layer ${layer.id} can't be filtered.`);
-    }
     const dataUrl = new URL(layerId, baseUrl).toString();
 
     // Fetch data based on filters

--- a/coordo-ts/src/types.ts
+++ b/coordo-ts/src/types.ts
@@ -34,5 +34,12 @@ export type LayerMetadata = {
     trigger: string;
     html?: string;
   };
-  schema?: FrictionlessSchema;
+  resource?: {
+    schema?: FrictionlessSchema;
+  },
+  references?: [{
+    name: string,
+    schema: FrictionlessSchema
+  }
+  ]
 };

--- a/coordo-ts/src/types.ts
+++ b/coordo-ts/src/types.ts
@@ -36,10 +36,11 @@ export type LayerMetadata = {
   };
   resource?: {
     schema?: FrictionlessSchema;
-  },
-  references?: [{
-    name: string,
-    schema: FrictionlessSchema
-  }
-  ]
+  };
+  references?: [
+    {
+      name: string;
+      schema: FrictionlessSchema;
+    },
+  ];
 };


### PR DESCRIPTION
### Objective

As a frontend developer, I want to access all schemas of all resources that have been used for computing the columns in the config.json.

### Context

Currently in the style.json, only the schema of the resource linked to the layer is transferred.
However, when computing the columns in the config.json, we perform some joins on other tables to access complementary data. Some of this data is categorical so we want to be able to access the labels in the frontend. Therefore, we need to add the schemas of those references in the layer metadata of the style.json.

### Solution 
What I did was adding all resources that had a reference to the layer's resource, even if we don't really know if they have been effectively used to compute the columns. 
A better way to do this might be to look at the joins performed in the final query but it seemed overcomplicated.